### PR TITLE
Update dependencies (fixed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
     "mkdirp": "^0.5.1",
     "pouchdb-collections": "^1.0.1",
     "sanitize-filename": "^1.6.0",
-    "tiny-queue": "0.2.0"
+    "tiny-queue": "^0.2.1"
   },
   "devDependencies": {
     "es5-shim": "^4.3.1",
-    "jshint": "2.8.0",
-    "levelup": "^0.18.2",
+    "jshint": "^2.9.3",
+    "levelup": "^1.3.2",
     "rimraf": "^2.5.4",
-    "tape": "^2.12.3",
-    "semantic-release": "^6.3.0"
+    "semantic-release": "^6.3.0",
+    "tape": "^4.6.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "url": "https://github.com/nolanlawson/fsdown/issues"
   },
   "homepage": "https://github.com/nolanlawson/fsdown#readme",
-  "author": "Nolan Lawson <nolan@nolanlawson.com>"
+  "author": "Nolan Lawson <nolan@nolanlawson.com>",
+  "abstract-leveldown": [
+    "abstract-leveldown"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "tiny-queue": "0.2.0"
   },
   "devDependencies": {
-    "browserify": "^4.1.2",
     "es5-shim": "^4.3.1",
     "jshint": "2.8.0",
     "levelup": "^0.18.2",


### PR DESCRIPTION
closes #5

The update of `abstract-leveldown` caused the problem. Most recent version 2.6.0, we use 0.12.3. I’ve configured Greenkeeper to ignore updates of it.

Let me know if that all works for you @nolanlawson
