### PR TITLE
fix: make data actually persist to disk

### DIFF
--- a/lib/localstorage-core.js
+++ b/lib/localstorage-core.js
@@ -33,19 +33,14 @@ function LocalStorageCore(dbname) {
   if (dbs.has(dbname)) {
     self._db = dbs.get(dbname);
   } else {
-    self._db = new collections.Map();
-    dbs.set(dbname, self._db);
-    // Read from disk once at startup.
-    try {
-      self._db.store = JSON.parse(fs.readFileSync(filename, 'utf-8'));
-    } catch (e) { /* ignore if the file isn't there */ }
     mkdirp.sync(path.dirname(filename));
+    self.import(dbname, filename);
   }
 
   // Periodically write to disk. Yes this is prone to failure, but this module isn't
   // designed to be bullet-proof.
   self._scheduleWrite = debounce(function () {
-    var json = JSON.stringify(self._db.store);
+    var json = JSON.stringify(self.export());
     fs.writeFile(filename, json, 'utf-8', function (error) {
       if (error) {
         console.log('ERROR: ' + filename + ' could not be written');
@@ -88,6 +83,28 @@ LocalStorageCore.prototype.remove = function (key, callback) {
     self._db.delete(key);
     self._scheduleWrite();
   });
+};
+
+LocalStorageCore.prototype.import = function (dbname, filename) {
+  var data = [];
+  // Read from disk once at startup.
+  try {
+    var json = JSON.parse(fs.readFileSync(filename, 'utf-8'));
+    data = Object.keys(json).map(function (key) {
+      return [key, json[key]];
+    });
+  } catch (e) { /* ignore if the file isn't there */ }
+
+  this._db = new collections.Map(data);
+  dbs.set(dbname, this._db);
+};
+
+LocalStorageCore.prototype.export = function () {
+  var result = {};
+  this._db.forEach(function (value, key) {
+    result[key] = value;
+  });
+  return result;
 };
 
 LocalStorageCore.destroy = function (dbname, callback) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "es5-shim": "^4.3.1",
     "jshint": "^2.9.3",
     "levelup": "^1.3.2",
+    "lolex": "^1.5.2",
     "rimraf": "^2.5.4",
     "semantic-release": "^6.3.0",
     "tape": "^4.6.0"

--- a/tests/persistence-tests.js
+++ b/tests/persistence-tests.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var fs = require('fs');
+var levelup = require('levelup');
+var lolex = require('lolex');
+var rimraf = require('rimraf');
+
+module.exports.setUp = function (leveldown, test, testCommon) {
+  test('setUp common', testCommon.setUp);
+  test('setUp db', function (t) {
+    var db = leveldown(testCommon.location());
+    db.open(t.end.bind(t));
+  });
+};
+
+module.exports.all = function (leveldown, test, testCommon) {
+  module.exports.setUp(leveldown, test, testCommon);
+
+  test('writes file', function (t) {
+    var clock = lolex.install();
+
+    rimraf.sync('.fsdown/persistence-write-test');
+    var db = levelup('.fsdown/persistence-write-test', {db: leveldown});
+    db.put('foo', 'bar', function (err) {
+      t.error(err);
+
+      clock.tick(1000);
+      clock.uninstall();
+
+      fs.readFile('.fsdown/persistence-write-test.json', 'utf-8', function (err, data) {
+        t.error(err);
+
+        t.is(data, '{"foo":"bar"}');
+        t.end();
+      });
+    });
+  });
+
+  test('reads file', function (t) {
+    fs.writeFileSync('.fsdown/persistence-read-test.json', '{"foo":"bar"}', 'utf-8');
+    var db = levelup('.fsdown/persistence-read-test', {db: leveldown});
+    db.get('foo', function (err, value) {
+      t.error(err);
+
+      t.is(value, 'bar');
+      t.end();
+    });
+  });
+};

--- a/tests/test.js
+++ b/tests/test.js
@@ -25,3 +25,4 @@ require('abstract-leveldown/abstract/ranges-test').all(localstorage, tape, testC
 require('abstract-leveldown/abstract/batch-test').all(localstorage, tape, testCommon);
 
 require('./custom-tests.js').all(localstorage, tape, testCommon);
+require('./persistence-tests.js').all(localstorage, tape, testCommon);


### PR DESCRIPTION
Adds `LocalStorageCore.export()` and `import(data)` for loading
data from a file into memory or dumping the current memory
contents to a file.

I will need help with tests.